### PR TITLE
Sup 15 set minimum stock quantities

### DIFF
--- a/supplywise/src/main/java/com/supplywise/supplywise/controllers/ItemStockController.java
+++ b/supplywise/src/main/java/com/supplywise/supplywise/controllers/ItemStockController.java
@@ -1,6 +1,8 @@
 package com.supplywise.supplywise.controllers;
 
 import com.supplywise.supplywise.model.ItemStock;
+import com.supplywise.supplywise.model.User;
+import com.supplywise.supplywise.model.Role;
 import com.supplywise.supplywise.services.ItemStockService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -9,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -92,6 +95,36 @@ public class ItemStockController {
         }
 
         logger.info("Item stock quantity updated successfully");
+        return new ResponseEntity<>(updatedItemStock.get(), HttpStatus.OK);
+    }
+
+    @Operation(summary = "Update minimum stock quantity", description = "Update the minimum stock quantity for an item")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Minimum quantity updated successfully"),
+        @ApiResponse(responseCode = "404", description = "Item stock not found"),
+        @ApiResponse(responseCode = "403", description = "User not authorized")
+    })
+    @PutMapping("/{id}/minimum-quantity")
+    public ResponseEntity<ItemStock> updateMinimumQuantity(
+            @PathVariable UUID id,
+            @RequestParam int minimumQuantity,
+            @AuthenticationPrincipal User user) {
+        
+        if (user.getRole() != Role.MANAGER_MASTER) {
+            logger.error("Unauthorized attempt to update minimum quantity");
+            return new ResponseEntity<>(HttpStatus.FORBIDDEN);
+        }
+
+        logger.info("Attempting to update minimum quantity for item stock");
+
+        Optional<ItemStock> updatedItemStock = itemStockService.updateMinimumQuantity(id, minimumQuantity);
+
+        if (!updatedItemStock.isPresent()) {
+            logger.error("Item stock not found");
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        logger.info("Minimum quantity updated successfully");
         return new ResponseEntity<>(updatedItemStock.get(), HttpStatus.OK);
     }
 

--- a/supplywise/src/main/java/com/supplywise/supplywise/model/ItemStock.java
+++ b/supplywise/src/main/java/com/supplywise/supplywise/model/ItemStock.java
@@ -20,13 +20,42 @@ public class ItemStock {
     @Column(name = "quantity", nullable = false)
     private int quantity;
 
+    @Column(name = "minimum_quantity", nullable = false)
+    private int minimumQuantity = 0;
+
+    @Column(name = "low_stock", nullable = false)
+    private boolean lowStock = false;
+
     @ManyToOne(fetch = FetchType.EAGER, optional = false)
     @JoinColumn(name = "item_properties_id", nullable = false)
     private ItemProperties itemProperties;
 
     public ItemStock(int quantity, ItemProperties itemProperties) {
         this.quantity = quantity;
+        this.minimumQuantity = 0;
         this.itemProperties = itemProperties;
+        this.updateLowStockStatus();
+    }
+
+    public ItemStock(int quantity, int minimumQuantity, ItemProperties itemProperties) {
+        this.quantity = quantity;
+        this.minimumQuantity = minimumQuantity;
+        this.itemProperties = itemProperties;
+        this.updateLowStockStatus();
+    }
+
+    private void updateLowStockStatus() {
+        this.lowStock = this.quantity < this.minimumQuantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+        updateLowStockStatus();
+    }
+
+    public void setMinimumQuantity(int minimumQuantity) {
+        this.minimumQuantity = minimumQuantity;
+        updateLowStockStatus();
     }
 
 }

--- a/supplywise/src/main/java/com/supplywise/supplywise/services/ItemStockService.java
+++ b/supplywise/src/main/java/com/supplywise/supplywise/services/ItemStockService.java
@@ -38,13 +38,26 @@ public class ItemStockService {
         return itemStockRepository.existsById(id);
     }
 
-    // Update an item stock's quantity (other fields stay the same)
+    // Update an item stock's quantity
     public Optional<ItemStock> updateItemStockQuantity(UUID id, int newQuantity) {
         Optional<ItemStock> itemStockOptional = itemStockRepository.findById(id);
 
         if (itemStockOptional.isPresent()) {
             ItemStock itemStock = itemStockOptional.get();
             itemStock.setQuantity(newQuantity);
+            return Optional.of(itemStockRepository.save(itemStock));
+        }
+
+        return Optional.empty();
+    }
+
+    // Update an item stock's minimum quantity
+    public Optional<ItemStock> updateMinimumQuantity(UUID id, int minimumQuantity) {
+        Optional<ItemStock> itemStockOptional = itemStockRepository.findById(id);
+
+        if (itemStockOptional.isPresent()) {
+            ItemStock itemStock = itemStockOptional.get();
+            itemStock.setMinimumQuantity(minimumQuantity);
             return Optional.of(itemStockRepository.save(itemStock));
         }
 

--- a/supplywise/src/test/java/com/supplywise/supplywise/services/ItemStockServiceTest.java
+++ b/supplywise/src/test/java/com/supplywise/supplywise/services/ItemStockServiceTest.java
@@ -131,6 +131,82 @@ class ItemStockServiceTest {
     }
 
     @Test
+    void testUpdateMinimumQuantity_Exists_ShouldUpdateMinimumQuantity() {
+        // Given
+        UUID itemStockId = UUID.randomUUID();
+        ItemProperties itemProperties = new ItemProperties();
+        ItemStock itemStock = new ItemStock(100, 50, itemProperties);
+        itemStock.setId(itemStockId);
+
+        when(itemStockRepository.findById(itemStockId)).thenReturn(Optional.of(itemStock));
+        when(itemStockRepository.save(any(ItemStock.class))).thenReturn(itemStock);
+
+        // When
+        Optional<ItemStock> result = itemStockService.updateMinimumQuantity(itemStockId, 125);
+
+        // Then
+        assertTrue(result.isPresent());
+        assertEquals(125, result.get().getMinimumQuantity());
+        assertTrue(result.get().isLowStock()); // quantity (100) < minimumQuantity (125)
+        verify(itemStockRepository, times(1)).save(itemStock);
+    }
+
+    @Test
+    void testUpdateMinimumQuantity_NotExists_ShouldReturnEmpty() {
+        // Given
+        UUID itemStockId = UUID.randomUUID();
+        when(itemStockRepository.findById(itemStockId)).thenReturn(Optional.empty());
+
+        // When
+        Optional<ItemStock> result = itemStockService.updateMinimumQuantity(itemStockId, 50);
+
+        // Then
+        assertFalse(result.isPresent());
+        verify(itemStockRepository, never()).save(any(ItemStock.class));
+    }
+
+    @Test
+    void testLowStockFlag_UpdateQuantityBelowMinimum_ShouldSetLowStockTrue() {
+        // Given
+        UUID itemStockId = UUID.randomUUID();
+        ItemProperties itemProperties = new ItemProperties();
+        ItemStock itemStock = new ItemStock(100, 50, itemProperties);
+        itemStock.setId(itemStockId);
+
+        when(itemStockRepository.findById(itemStockId)).thenReturn(Optional.of(itemStock));
+        when(itemStockRepository.save(any(ItemStock.class))).thenReturn(itemStock);
+
+        // When
+        Optional<ItemStock> result = itemStockService.updateItemStockQuantity(itemStockId, 40);
+
+        // Then
+        assertTrue(result.isPresent());
+        assertTrue(result.get().isLowStock());
+        verify(itemStockRepository, times(1)).save(itemStock);
+    }
+
+    @Test
+    void testLowStockFlag_UpdateQuantityAboveMinimum_ShouldSetLowStockFalse() {
+        // Given
+        UUID itemStockId = UUID.randomUUID();
+        ItemProperties itemProperties = new ItemProperties();
+        ItemStock itemStock = new ItemStock(40, 50, itemProperties);
+        itemStock.setId(itemStockId);
+        itemStock.setLowStock(true);
+
+        when(itemStockRepository.findById(itemStockId)).thenReturn(Optional.of(itemStock));
+        when(itemStockRepository.save(any(ItemStock.class))).thenReturn(itemStock);
+
+        // When
+        Optional<ItemStock> result = itemStockService.updateItemStockQuantity(itemStockId, 60);
+
+        // Then
+        assertTrue(result.isPresent());
+        assertFalse(result.get().isLowStock());
+        verify(itemStockRepository, times(1)).save(itemStock);
+    }
+
+    @Test
     void testDeleteItemStockById_Exists_ShouldDelete() {
         // Given
         UUID itemStockId = UUID.randomUUID();


### PR DESCRIPTION
Set Minimum Stock Quantities (User Story):
- the manager masters can set a minimum stock quantity
- when this is set, the low stock status is updated (True - if the actual quantity is less than the minimum stock quantity; False - otherwise)
- code updated in ItemStock's model, controller, and service
- tests to ItemStock's controller and service also done